### PR TITLE
Added Content-Type json header to data POST

### DIFF
--- a/Sources/SimpleAnalytics/AnalyticsSubmitter.swift
+++ b/Sources/SimpleAnalytics/AnalyticsSubmitter.swift
@@ -51,7 +51,8 @@ struct AnalyticsSubmitter: AnalyticsSubmitting {
         do {
             let data = try encoder.encode(requestItem)
             urlRequest.httpBody = data
-            
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
             let config = URLSessionConfiguration.default
             config.timeoutIntervalForRequest = 30
             config.timeoutIntervalForResource = 120


### PR DESCRIPTION
Added a Content-Type header (application/json) to properly send JSON.  Without this, the JSON was being converted to a single url encoded string and sent as a form post, instead of a JSON post.  Node.js express was unable to decode it,